### PR TITLE
Add CanEqual instance to GenNewType

### DIFF
--- a/src/main/scala/dev/profunktor/newtypes.scala
+++ b/src/main/scala/dev/profunktor/newtypes.scala
@@ -7,6 +7,7 @@ object NewType:
     opaque type Type = A
     def apply(a: A): Type = a
     extension (a: Type) def value: A = a
+    given (using CanEqual[A, A]): CanEqual[Type, Type] = CanEqual.derived
   end GenNewType
 
   class NewTypeBool extends GenNewType[Boolean]:


### PR DESCRIPTION
Based on https://contributors.scala-lang.org/t/synthesize-constructor-for-opaque-types/4616/140

Given
```
val Name = NewType.of[Foo]
val Email = NewType.of[Foo]
```
If `strictEquality` is _not_ enabled:
- `Name(foo) == Name(bar)` will compile
- `Name(foo) == Email(bar)` will not compile

If `strictEquality` is enabled:
- `Name(foo) == Name(bar)` will compile _iff_ a given `CanEqual[Foo, Foo]` instance exists
- `Name(foo) == Email(bar)` will not compile